### PR TITLE
reload iframe

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "mhutchie.git-graph",
+    "esbenp.prettier-vscode",
+    "formulahendry.auto-rename-tag"
+  ]
+}

--- a/src/store/plugins/trilist.ts
+++ b/src/store/plugins/trilist.ts
@@ -48,7 +48,9 @@ function setupTrilist(store: Store, options: IControlSystemActions) {
         let updatedUrl = currentUrl;
 
         // Remove existing '_t' parameter if it exists
-        updatedUrl = updatedUrl.replace(/[?&]_t=[^&]*/g, '');
+        updatedUrl = updatedUrl.replace(/[?&]_t=[^&]*(&|$)/g, (match, p1) => p1 === '&' ? '' : '');
+        // Remove any trailing '?' or '&' left after parameter removal
+        updatedUrl = updatedUrl.replace(/[?&]$/, '');
 
         // Add the new '_t' parameter
         const separator = updatedUrl.includes('?') ? '&' : '?';

--- a/src/store/plugins/trilist.ts
+++ b/src/store/plugins/trilist.ts
@@ -1,5 +1,6 @@
 import { CrComLib } from '@pepperdash/ch5-crcomlib-lite';
 import { Store, UnknownAction } from '@reduxjs/toolkit';
+import { RootState } from '../store';
 
 export interface IControlSystemActions {
   actions: {
@@ -20,6 +21,43 @@ function setupTrilist(store: Store, options: IControlSystemActions) {
   CrComLib.subscribeState('s', 'Csig.Ip_Address_fb', (value: string) =>
     store.dispatch(options.actions.setPanelIpAddress(value))
   );
+
+  CrComLib.subscribeState('b', '1', (value: boolean) => {
+    //pulsed from control system. Triggering on falling edge
+    if (value) {
+      return;
+    }
+    // Get current mcAppUrl from store
+    const currentState = store.getState() as RootState;
+    const currentUrl = currentState.touchPanel.mcAppUrl;
+
+    if (currentUrl) {
+      // Generate a random value
+      const randomValue = Math.random().toString(36).substring(2, 15);
+
+      // Parse the URL to add/update the random query parameter
+      try {
+        const url = new URL(currentUrl);
+        url.searchParams.set('_t', randomValue);
+        const updatedUrl = url.toString();
+
+        // Update the store with the new URL
+        store.dispatch(options.actions.setMcAppUrl(updatedUrl));
+      } catch (error) {
+        // If URL parsing fails, handle the parameter manually
+        let updatedUrl = currentUrl;
+
+        // Remove existing '_t' parameter if it exists
+        updatedUrl = updatedUrl.replace(/[?&]_t=[^&]*/g, '');
+
+        // Add the new '_t' parameter
+        const separator = updatedUrl.includes('?') ? '&' : '?';
+        updatedUrl = `${updatedUrl}${separator}_t=${randomValue}`;
+
+        store.dispatch(options.actions.setMcAppUrl(updatedUrl));
+      }
+    }
+  });
 
   CrComLib.subscribeState('s', '1', (value: string) =>
     store.dispatch(options.actions.setMcAppUrl(value))

--- a/src/store/plugins/trilist.ts
+++ b/src/store/plugins/trilist.ts
@@ -48,8 +48,14 @@ function setupTrilist(store: Store, options: IControlSystemActions) {
         let updatedUrl = currentUrl;
 
         // Remove existing '_t' parameter if it exists
-        updatedUrl = updatedUrl.replace(/[?&]_t=[^&]*(&|$)/g, (match, p1) => p1 === '&' ? '' : '');
-        // Remove any trailing '?' or '&' left after parameter removal
+        // Handle _t at the beginning: ?_t=value&... or ?_t=value (end)
+        updatedUrl = updatedUrl.replace(/\?_t=[^&]*(&|$)/g, (_, p1) => {
+          return p1 === '&' ? '?' : '';
+        });
+        // Handle _t in the middle/end: &_t=value&... or &_t=value (end)
+        updatedUrl = updatedUrl.replace(/&_t=[^&]*/g, '');
+
+        // Clean up any trailing '?' or '&'
         updatedUrl = updatedUrl.replace(/[?&]$/, '');
 
         // Add the new '_t' parameter


### PR DESCRIPTION
This pull request introduces a new VSCode workspace configuration and adds a feature to the `trilist` plugin that updates the `mcAppUrl` in the store with a random query parameter when triggered by a control system pulse. The changes improve developer experience and enhance the app's ability to refresh or invalidate URLs based on control system events.

**Developer tooling:**
* Added `.vscode/extensions.json` to recommend useful extensions for linting, formatting, and Git visualization.

**trilist plugin enhancements:**
* Updated import in `src/store/plugins/trilist.ts` to include `RootState` for improved type safety when accessing the store state.
* Added a new `CrComLib.subscribeState('b', '1', ...)` handler to detect control system pulses and update the `mcAppUrl` in the store with a random query parameter, ensuring proper URL refresh logic even if URL parsing fails.

- **chore: add settings for prettier and format on save**
- **feat: refresh iframe by adding a random value to the url**
